### PR TITLE
chore: add root check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "test": "cd web && pnpm test",
+    "check": "make lint && make typecheck && make test",
     "host": "cargo build --release --manifest-path browser-extension/native-host/Cargo.toml",
     "host:mac": "cargo build --release --manifest-path browser-extension/native-host/Cargo.toml",
     "host:win": "cargo build --release --target x86_64-pc-windows-gnu --manifest-path browser-extension/native-host/Cargo.toml",


### PR DESCRIPTION
## Summary
- add a root `pnpm run check` script that runs the existing lint, typecheck, and test Make targets
- keeps the existing root `test` shortcut unchanged

Closes #2

## Verification
- `python3 -m json.tool package.json`
- `make -n lint typecheck test` (dry-run confirms the script targets resolve to existing lint/typecheck/test commands)

Note: this environment does not currently have Node/pnpm installed, so I verified the package JSON and command wiring without executing the full JS/Rust toolchain.