### PR TITLE
fix: guard main diagnostics in development

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,15 +1,17 @@
 // ============================================================================
 // Early COOP/COEP Diagnostics
 // ============================================================================
-console.log('[Main Thread] Early diagnostics:')
-console.log('[Main Thread]  - typeof SharedArrayBuffer:', typeof SharedArrayBuffer)
-console.log(
-  '[Main Thread]  - SharedArrayBuffer available:',
-  typeof SharedArrayBuffer !== 'undefined'
-)
-console.log('[Main Thread]  - crossOriginIsolated:', self.crossOriginIsolated)
-console.log('[Main Thread]  - location:', window.location.href)
-console.log('[Main Thread]  - navigator.userAgent:', navigator.userAgent)
+if (import.meta.env.DEV) {
+  console.log('[Main Thread] Early diagnostics:')
+  console.log('[Main Thread]  - typeof SharedArrayBuffer:', typeof SharedArrayBuffer)
+  console.log(
+    '[Main Thread]  - SharedArrayBuffer available:',
+    typeof SharedArrayBuffer !== 'undefined'
+  )
+  console.log('[Main Thread]  - crossOriginIsolated:', self.crossOriginIsolated)
+  console.log('[Main Thread]  - location:', window.location.href)
+  console.log('[Main Thread]  - navigator.userAgent:', navigator.userAgent)
+}
 
 import React from 'react'
 import ReactDOM from 'react-dom/client'


### PR DESCRIPTION
## Summary
- wrap the early COOP/COEP diagnostic console logging in `import.meta.env.DEV`
- keeps the diagnostics available during local development while avoiding production console output of URL/user-agent details

Closes #11

## Verification
- `python3` static guard check confirmed the Main Thread diagnostics are inside the DEV branch
- `pnpm -C web run typecheck` not run in this cron VM because Node/pnpm are unavailable here
