### PR TITLE
fix: localize database refresh dialog strings

### DIFF
--- a/packages/i18n/src/locales/en-US.ts
+++ b/packages/i18n/src/locales/en-US.ts
@@ -57,6 +57,7 @@ export const enUS = {
     deleteFailed: "Failed to delete, please try again later",
     // Database refresh dialog
     databaseConnectionLost: "Database connection lost",
+    databaseConnectionLostDescription: "Refresh the page to reconnect to the local database.",
     whatHappened: "What happened?",
     databaseHandleInvalidExplanation:
       "After browser tab hibernation, the database file handle becomes invalid. This is normal browser behavior.",
@@ -68,6 +69,7 @@ export const enUS = {
     willAutoRecoverAfterRefresh:
       "Database connection will automatically recover after page refresh.",
     refreshPage: "Refresh Page",
+    refreshPageParenthetical: "(Refresh Page)",
     cannotCloseDialog:
       "This dialog cannot be closed - please click the button above to refresh the page",
     // Storage loading screen

--- a/packages/i18n/src/locales/ja-JP.ts
+++ b/packages/i18n/src/locales/ja-JP.ts
@@ -60,6 +60,7 @@ export const jaJP = {
     deleteFailed: "削除に失敗しました。しばらくしてから再試行してください",
     // Database refresh dialog
     databaseConnectionLost: "データベース接続が切断されました",
+    databaseConnectionLostDescription: "ページを更新してローカルデータベースに再接続してください。",
     whatHappened: "何が発生しましたか？",
     databaseHandleInvalidExplanation:
       "ブラウザタブが休止状態になると、データベースファイルハンドルが無効になります。これは通常のブラウザ動作です。",
@@ -71,6 +72,7 @@ export const jaJP = {
     willAutoRecoverAfterRefresh:
       "ページを更新すると、データベース接続は自動的に回復します。",
     refreshPage: "ページを更新",
+    refreshPageParenthetical: "（ページを更新）",
     cannotCloseDialog:
       "このダイアログは閉じられません - 上のボタンをクリックしてページを更新してください",
     databaseInitFailed: "データベースの初期化に失敗しました",

--- a/packages/i18n/src/locales/ko-KR.ts
+++ b/packages/i18n/src/locales/ko-KR.ts
@@ -59,6 +59,7 @@ export const koKR = {
     deleteFailed: "삭제에 실패했습니다. 나중에 다시 시도해 주세요",
     // Database refresh dialog
     databaseConnectionLost: "데이터베이스 연결이 끊어졌습니다",
+    databaseConnectionLostDescription: "페이지를 새로고침하여 로컬 데이터베이스에 다시 연결하세요.",
     whatHappened: "무슨 일이 발생했나요?",
     databaseHandleInvalidExplanation:
       "브라우저 탭이 최대 절전 모드 후 데이터베이스 파일 핸들이 무효가 됩니다. 이는 정상적인 브라우저 동작입니다.",
@@ -70,6 +71,7 @@ export const koKR = {
     willAutoRecoverAfterRefresh:
       "페이지를 새로고침하면 데이터베이스 연결이 자동으로 복원됩니다.",
     refreshPage: "페이지 새로고침",
+    refreshPageParenthetical: "(페이지 새로고침)",
     cannotCloseDialog:
       "이 대화상자는 닫을 수 없습니다 - 위 버튼을 클릭하여 페이지를 새로고침해 주세요",
     databaseInitFailed: "데이터베이스 초기화 실패",

--- a/packages/i18n/src/locales/zh-CN.ts
+++ b/packages/i18n/src/locales/zh-CN.ts
@@ -55,6 +55,7 @@ export const zhCN = {
     deleteFailed: "删除失败，请稍后重试",
     // Database refresh dialog
     databaseConnectionLost: "数据库连接已断开",
+    databaseConnectionLostDescription: "刷新页面以重新连接本地数据库。",
     whatHappened: "发生了什么？",
     databaseHandleInvalidExplanation:
       "浏览器标签页休眠后，数据库文件句柄失效。这是浏览器的正常行为。",
@@ -64,6 +65,7 @@ export const zhCN = {
     dataStoredInOPFS: "数据存储在浏览器的 OPFS 中，只是暂时无法访问。",
     willAutoRecoverAfterRefresh: "刷新页面后将自动恢复数据库连接。",
     refreshPage: "刷新页面",
+    refreshPageParenthetical: "（刷新页面）",
     cannotCloseDialog: "此对话框无法关闭 - 请点击上方按钮刷新页面",
     databaseInitFailed: "数据库初始化失败",
     databaseResetExplanation:

--- a/web/src/components/DatabaseRefreshDialog.tsx
+++ b/web/src/components/DatabaseRefreshDialog.tsx
@@ -59,7 +59,7 @@ export function DatabaseRefreshDialog({ isOpen }: DatabaseRefreshDialogProps) {
         {/* Header */}
         <div className="px-6 py-4 text-center">
           <h3 className="text-xl font-bold text-neutral-900 dark:text-neutral-100">{t('app.databaseConnectionLost')}</h3>
-          <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">Database Connection Lost</p>
+          <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">{t('app.databaseConnectionLostDescription')}</p>
         </div>
 
         {/* Content */}
@@ -91,7 +91,7 @@ export function DatabaseRefreshDialog({ isOpen }: DatabaseRefreshDialogProps) {
             className="w-full rounded-lg bg-primary-600 px-4 py-3 text-base font-semibold text-white shadow-sm transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
           >
             {t('app.refreshPage')}
-            <span className="ml-2 text-sm opacity-80">(Refresh Page)</span>
+            <span className="ml-2 text-sm opacity-80">{t('app.refreshPageParenthetical')}</span>
           </button>
           <p className="mt-3 text-center text-xs text-neutral-500 dark:text-neutral-400">
             {t('app.cannotCloseDialog')}


### PR DESCRIPTION
## Summary
- replace the duplicate hardcoded DatabaseRefreshDialog subtitle with an i18n description key
- replace the hardcoded refresh-button parenthetical with locale-backed text
- add the new keys to en-US, zh-CN, ja-JP, and ko-KR

Closes #18

## Verification
- `python3` static check confirmed all four locale files include `databaseConnectionLostDescription` and `refreshPageParenthetical`
- `python3` static check confirmed `DatabaseRefreshDialog.tsx` no longer contains the hardcoded `Database Connection Lost` subtitle or `(Refresh Page)` span text
- `git diff --check`

Note: this cron VM does not have `node`/`pnpm`, so I could not run `pnpm -C web run typecheck` here.