### PR TITLE
feat: add word wrap keyboard shortcut

### DIFF
--- a/packages/i18n/src/locales/en-US/keyboardShortcuts.ts
+++ b/packages/i18n/src/locales/en-US/keyboardShortcuts.ts
@@ -14,6 +14,7 @@ export const keyboardShortcuts = {
     toggleSidebar: "Toggle sidebar",
     openWorkspaceSettings: "Open workspace settings",
     toggleShortcutsHelp: "Toggle this shortcuts help",
+    toggleWordWrap: "Toggle word wrap",
     closePanels: "Close panels / dialogs",
   },
 } as const

--- a/packages/i18n/src/locales/ja-JP/keyboardShortcuts.ts
+++ b/packages/i18n/src/locales/ja-JP/keyboardShortcuts.ts
@@ -14,6 +14,7 @@ export const keyboardShortcuts = {
     toggleSidebar: "サイドバーの切り替え",
     openWorkspaceSettings: "ワークスペース設定を開く",
     toggleShortcutsHelp: "ショートカットヘルプの切り替え",
+    toggleWordWrap: "折り返しの切り替え",
     closePanels: "パネル / ダイアログを閉じる",
   },
 } as const

--- a/packages/i18n/src/locales/ko-KR/keyboardShortcuts.ts
+++ b/packages/i18n/src/locales/ko-KR/keyboardShortcuts.ts
@@ -14,6 +14,7 @@ export const keyboardShortcuts = {
     toggleSidebar: "사이드바 전환",
     openWorkspaceSettings: "작업 공간 설정 열기",
     toggleShortcutsHelp: "단축키 도움말 전환",
+    toggleWordWrap: "자동 줄바꿈 전환",
     closePanels: "패널 / 대화상자 닫기",
   },
 } as const

--- a/packages/i18n/src/locales/zh-CN/keyboardShortcuts.ts
+++ b/packages/i18n/src/locales/zh-CN/keyboardShortcuts.ts
@@ -14,6 +14,7 @@ export const keyboardShortcuts = {
     toggleSidebar: "切换侧边栏",
     openWorkspaceSettings: "打开工作区设置",
     toggleShortcutsHelp: "切换快捷键帮助",
+    toggleWordWrap: "切换自动换行",
     closePanels: "关闭面板 / 对话框",
   },
 } as const

--- a/web/components/file-viewer/FilePreview.tsx
+++ b/web/components/file-viewer/FilePreview.tsx
@@ -1088,7 +1088,7 @@ export function FilePreview({ filePath, fileHandle, onClose, blob: externalBlob 
               minimap: { enabled: display.showMiniMap },
               lineNumbers: display.showLineNumbers ? 'on' : 'off',
               scrollBeyondLastLine: false,
-              wordWrap: 'on',
+              wordWrap: display.wordWrap ? 'on' : 'off',
               automaticLayout: true,
               fontSize: display.fontSize === 'small' ? 13 : display.fontSize === 'large' ? 16 : 14,
               padding: { top: 8, bottom: 8 },

--- a/web/components/layout/WorkspaceLayout.tsx
+++ b/web/components/layout/WorkspaceLayout.tsx
@@ -177,6 +177,8 @@ export function WorkspaceLayout({
   const setActiveResourceTab = useWorkspacePreferencesStore((s) => s.setActiveResourceTab)
   const panelSizes = useWorkspacePreferencesStore((s) => s.panelSizes)
   const filePreviewMode = useWorkspacePreferencesStore((s) => s.filePreviewMode)
+  const wordWrapEnabled = useWorkspacePreferencesStore((s) => s.display.wordWrap)
+  const setWordWrap = useWorkspacePreferencesStore((s) => s.setWordWrap)
 
   // Phase 4: Dialog states
   const [showCommandPalette, setShowCommandPalette] = useState(false)
@@ -528,6 +530,14 @@ export function WorkspaceLayout({
         return
       }
 
+      // Alt + Z to toggle word wrap. Match on e.code (physical key) so it
+      // works on macOS too, where Alt+Z produces 'Ω' as e.key.
+      if (e.altKey && e.code === 'KeyZ' && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault()
+        setWordWrap(!wordWrapEnabled)
+        return
+      }
+
       // ESC to close panels
       if (e.key === 'Escape') {
         if (showCommandPalette) {
@@ -568,6 +578,8 @@ export function WorkspaceLayout({
     setSidebarCollapsed,
     setActiveResourceTab,
     closeWebContainerPanel,
+    wordWrapEnabled,
+    setWordWrap,
   ])
 
   // hasActiveConversation is computed via store selector above (avoids re-renders)

--- a/web/hooks/useKeyboardShortcuts.ts
+++ b/web/hooks/useKeyboardShortcuts.ts
@@ -238,4 +238,10 @@ export const DEFAULT_SHORTCUTS: (Omit<KeyboardShortcut, 'handler' | 'disabled' |
     description: 'Close panels / dialogs',
     labelKey: 'keyboardShortcuts.actions.closePanels',
   },
+  {
+    key: 'z',
+    altKey: true,
+    description: 'Toggle word wrap',
+    labelKey: 'keyboardShortcuts.actions.toggleWordWrap',
+  },
 ]


### PR DESCRIPTION
## Summary
- add Alt+Z as a global word-wrap toggle shortcut
- show the shortcut in the existing keyboard shortcut registry/help dialog
- connect FilePreview Monaco word wrap to the persisted workspace preference instead of forcing wrap on

Closes #7

## Verification
- Python static guard confirmed Alt+Z registration, shortcut hook mounting, preference toggle, and FilePreview wordWrap binding
- `git diff --check`

Note: `pnpm` is not installed in this cron VM, so I could not run the repo typecheck locally.